### PR TITLE
feat: use raw graphql query in gatsby-themes.yaml

### DIFF
--- a/lib/entry.js
+++ b/lib/entry.js
@@ -1,41 +1,10 @@
 #!/usr/bin/env node
-
 const yaml = require('js-yaml')
 const fs = require('fs-extra')
 const loader = require('./loader')
 const yargs = require('yargs');
 const { spawn, exec } = require('child_process')
 const path = require('path')
-
-const addQueryAlias = (key, value) => {
-  const partial = `
-    ${key}: ${value}
-  `
-  return partial
-}
-
-const joinPartialQueries = (partials) => {
-  var query = ``
-
-  partials.forEach(entry => {
-    const key = entry[0]
-    const value = entry[1]
-
-    const partial = addQueryAlias(key, value)
-    query += partial
-  })
-
-  return query
-}
-
-const composeGraphqlQuery = (queries) => {
-
-  const entries = Object.entries(queries)
-  const query = joinPartialQueries(entries)
-
-  return `{ ${query} }`
-
-}
 
 exports.loadPlugins = () => {
   const config = loader.loadJsonSync(path.resolve(process.cwd(), 'theme.json'))
@@ -45,14 +14,13 @@ exports.loadPlugins = () => {
 exports.fetchDataFromSources = async (graphql) => {
 
   const config = loader.loadJsonSync(path.resolve(process.cwd(), 'theme.json'))
-  const dataQueries = config.data
-  const query = composeGraphqlQuery(dataQueries)
+  const query = config.data
 
   try {
     return await graphql(query)
   } catch (e) {
     // TODO: Handle errors when there is parsing issues, prevent silent fail
 
-    throw e
+    throw ` There is an error in your gatsby-themes.yaml. Check your graphql syntax. ${e}`
   }
 }

--- a/templates/gatsby-themes-v1.yaml
+++ b/templates/gatsby-themes-v1.yaml
@@ -4,10 +4,11 @@ themesDir: themes
 theme: gatsby-theme-identity
 themes:
   gatsby-theme-identity:
-    data:
-      siteData: >
+    data: >
+      {
         site {
           siteMetadata {
             title
           }
         }
+      }

--- a/test/schemas/gatsby-themes-v1.yaml
+++ b/test/schemas/gatsby-themes-v1.yaml
@@ -11,8 +11,15 @@ themes:
         options:
           spaceId: process.env.CONTENTFUL_SPACE_ID
           accessToken: process.env.CONTENTFUL_DELIVERY_TOKEN
-    data:
-      bio: >
+    data: >
+      {
+
+        site {
+          siteMetadata {
+            title
+          }
+        }
+
         contentfulBio (
           name: {
             regex: "/identity/i"
@@ -28,9 +35,5 @@ themes:
             }
           }
         }
-      siteData: >
-        site {
-          siteMetadata {
-            title
-          }
-        }
+
+      }


### PR DESCRIPTION
removes the named requirement in the data section of gatsby-themes.yaml.